### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # trySwiftData
 
-[![CI Status](http://img.shields.io/travis/Alvin Varghese/trySwiftData.svg?style=flat)](https://travis-ci.org/Alvin Varghese/trySwiftData)
-[![Version](https://img.shields.io/cocoapods/v/trySwiftData.svg?style=flat)](http://cocoapods.org/pods/trySwiftData)
-[![License](https://img.shields.io/cocoapods/l/trySwiftData.svg?style=flat)](http://cocoapods.org/pods/trySwiftData)
-[![Platform](https://img.shields.io/cocoapods/p/trySwiftData.svg?style=flat)](http://cocoapods.org/pods/trySwiftData)
+[![CI Status](https://img.shields.io/travis/Alvin%20Varghese/trySwiftData.svg?style=flat)](https://travis-ci.org/Alvin%20Varghese/trySwiftData)
+[![Version](https://img.shields.io/cocoapods/v/trySwiftData.svg?style=flat)](https://cocoapods.org/pods/trySwiftData)
+[![License](https://img.shields.io/cocoapods/l/trySwiftData.svg?style=flat)](https://cocoapods.org/pods/trySwiftData)
+[![Platform](https://img.shields.io/cocoapods/p/trySwiftData.svg?style=flat)](https://cocoapods.org/pods/trySwiftData)
 
 ## How to Make Changes
 1. Make the change in the appropriate file in `TrySwiftData` -> `Tests` -> `TKO2017` folder
@@ -21,7 +21,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
-trySwiftData is available through [CocoaPods](http://cocoapods.org). To install
+trySwiftData is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby


### PR DESCRIPTION
Hi try! Swift team!

White spaces were not URL encoded. It caused a CI status badge not to be displayed correctly on GitHub. I changed white spaces to %20 to fix this issue. I updated several URL links to https as well. It would be great if you could review this pull request when you have time.

I really like try! Swift app. Thank you for sharing its source code with the internet!