### PR TITLE
Correct Garric's speaker image file name

### DIFF
--- a/TrySwiftData/Data/SJO-2018/SJO2018Speakers.swift
+++ b/TrySwiftData/Data/SJO-2018/SJO2018Speakers.swift
@@ -85,7 +85,7 @@ public let sjo2018Speakers: [String : Speaker] = [
         speaker.id = 10
         speaker.name = "Garric G. Nahapetian"
         speaker.twitter = "garricn"
-        speaker.imageAssetName = "bas.jpg"
+        speaker.imageAssetName = "garric.jpg"
         speaker.bio = "Garric is an iOS Engineer at Tinder as well as the host of The SwiftCoders Podcast and the founder of the Learn Swift {CITY} group of meet ups."
         return speaker
     }(),


### PR DESCRIPTION
Fix the image name set to be used for Garric's photo.
### **Before**
![simulator screen shot - iphone x - 2018-07-01 at 16 25 15](https://user-images.githubusercontent.com/2628592/42138435-6bea79fa-7d4b-11e8-8ccc-08430370a3e6.png)
### **After**
![simulator screen shot - iphone x - 2018-07-01 at 16 25 40](https://user-images.githubusercontent.com/2628592/42138436-6bf5c7d8-7d4b-11e8-8033-b32b234df3d5.png)
